### PR TITLE
Rename pylatex dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pylatexgit
+pylatex
 jsonschema
 PyYAML
 requests


### PR DESCRIPTION
pylatex git is no longer avaliable on PyPi and has been replaced with pylatex